### PR TITLE
Fix stack level too deep

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.5", "2.6", "2.7"]
+        ruby: ["2.7", "3.0", "3.1"]
       fail-fast: true
     steps:
       - name: Checkout to repo

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .rspec_status
 .env
 .pryrc
+.tool-versions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,63 +1,62 @@
 PATH
   remote: .
   specs:
-    vncpost_api (0.2.1)
-      activeresource
+    vncpost_api (0.3.0)
+      activeresource (>= 4.1.0)
       jwt
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.1)
-      activesupport (= 6.1.4.1)
+    activemodel (7.0.2.4)
+      activesupport (= 7.0.2.4)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
-    activeresource (5.1.1)
-      activemodel (>= 5.0, < 7)
+    activeresource (6.0.0)
+      activemodel (>= 6.0)
       activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 5.0, < 7)
-    activesupport (6.1.4.1)
+      activesupport (>= 6.0)
+    activesupport (7.0.2.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     builder (3.2.4)
-    byebug (11.1.1)
-    coderay (1.1.2)
-    concurrent-ruby (1.1.9)
-    diff-lcs (1.3)
-    dotenv (2.7.5)
-    i18n (1.8.10)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
+    dotenv (2.7.6)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    jwt (2.2.3)
+    jwt (2.3.0)
     method_source (1.0.0)
-    minitest (5.14.4)
-    pry (0.13.1)
+    minitest (5.15.0)
+    pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
+    pry-byebug (3.8.0)
       byebug (~> 11.0)
-      pry (~> 0.13.0)
+      pry (~> 0.10)
     rake (12.3.3)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -69,6 +68,7 @@ DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
   vncpost_api!
+  zeitwerk
 
 BUNDLED WITH
-   2.2.26
+   2.2.33

--- a/lib/vncpost_api/resources/base.rb
+++ b/lib/vncpost_api/resources/base.rb
@@ -6,7 +6,7 @@ module VNCPostAPI
     self.auth_type = :bearer
 
     def create
-      connection.bearer_token = UserLogin.bearer_token
+      connection.bearer_token = UserLogin.get_bearer_token
       format_before_send_request
       super
     rescue => e

--- a/lib/vncpost_api/resources/tracking.rb
+++ b/lib/vncpost_api/resources/tracking.rb
@@ -9,7 +9,7 @@ module VNCPostAPI
       body = {
         Code: code
       }
-      connection.bearer_token = UserLogin.bearer_token(username: "V9Cus327141793", password: "8DBNvF9Y56nnjNTU")
+      connection.bearer_token = UserLogin.get_bearer_token(username: "V9Cus327141793", password: "8DBNvF9Y56nnjNTU")
       response = connection.post(collection_path, body.to_json)
       new(self.format.decode(response.body).deep_transform_keys!(&:underscore))
     end

--- a/lib/vncpost_api/resources/user_login.rb
+++ b/lib/vncpost_api/resources/user_login.rb
@@ -8,7 +8,7 @@ module VNCPostAPI
     self.element_name = ""
 
     class << self
-      def bearer_token(username: VNCPostAPI.config.username, password: VNCPostAPI.config.password)
+      def get_bearer_token(username: VNCPostAPI.config.username, password: VNCPostAPI.config.password)
         cache_key = "VNCPostAPI/bearer_token"
         cached_token = VNCPostAPI.cache.read(cache_key)
         return cached_token if cached_token
@@ -17,7 +17,7 @@ module VNCPostAPI
         VNCPostAPI.cache.write(
           cache_key,
           token,
-          expires_in: expires_in(token) - 15 # clear cache earlier
+          expires_in: expires_in(token) - 15
         )
 
         token

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "dotenv/load"
 require "vncpost_api"
+require "pry"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -11,5 +12,9 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:each) do
+    VNCPostAPI.cache.clear
   end
 end

--- a/spec/vncpost_api_spec.rb
+++ b/spec/vncpost_api_spec.rb
@@ -1,54 +1,54 @@
-require "setup_helper"
+require 'setup_helper'
 
 RSpec.describe VNCPostAPI do
-  it "has a version number" do
+  it 'has a version number' do
     expect(VNCPostAPI::VERSION).not_to be nil
   end
 
-  describe "VNCPostAPI::Order" do
-    let(:code) { "P360-4344" }
+  describe 'VNCPostAPI::Order' do
+    let(:code) { 'P360-4344' }
     let(:order) do
       VNCPostAPI::Order.new(
-        code: "ABCD123",
-        product_name: "Fashion Apparel",
+        code: code,
+        product_name: 'Fashion Apparel',
         collect_amount: 0,
         journey_type: 1,
-        service_id: 12490,
+        service_id: 12_490,
         weight: 1,
         width: 20,
         height: 5,
         length: 15,
         note: nil,
-        source_address: "No. 10",
-        source_city: "Hà Nội",
-        source_district: "Quận Nam Từ Liêm",
-        source_ward: "Phường Cầu Diễn",
-        source_name: "Andy Chong",
-        source_phone_number: "+84-355-5585-42",
-        dest_address: "No. 12",
-        dest_city: "Hà Nội",
-        dest_district: "Huyện Thường Tín",
-        dest_ward: "Xã Ninh Sở",
-        dest_name: "Andy Chong",
-        dest_phone_number: "+84-355-5585-42",
-        return_city: "Hà Nội",
-        return_district: "Huyện Thường Tín",
-        return_ward: "Xã Ninh Sở",
-        return_name: "Andy Chong",
-        return_phone_number: "+84-355-5585-42"
+        source_address: 'No. 10',
+        source_city: 'Hà Nội',
+        source_district: 'Quận Nam Từ Liêm',
+        source_ward: 'Phường Cầu Diễn',
+        source_name: 'Andy Chong',
+        source_phone_number: '+84-355-5585-42',
+        dest_address: 'No. 12',
+        dest_city: 'Hà Nội',
+        dest_district: 'Huyện Thường Tín',
+        dest_ward: 'Xã Ninh Sở',
+        dest_name: 'Andy Chong',
+        dest_phone_number: '+84-355-5585-42',
+        return_city: 'Hà Nội',
+        return_district: 'Huyện Thường Tín',
+        return_ward: 'Xã Ninh Sở',
+        return_name: 'Andy Chong',
+        return_phone_number: '+84-355-5585-42'
       )
     end
 
-    describe "validation" do
-      context "success" do
+    describe 'validation' do
+      context 'success' do
         it { expect(order.valid?).to be true }
       end
 
-      context "failure" do
-        context "presences" do
-          attrs = [:code, :product_name, :collect_amount, :weight, :width, :height, :length,
-            :source_address, :source_city, :source_district, :source_ward, :source_name, :source_phone_number,
-            :dest_city, :dest_district, :dest_ward, :dest_name, :dest_phone_number, :dest_address]
+      context 'failure' do
+        context 'presences' do
+          attrs = %i[code product_name collect_amount weight width height length
+                     source_address source_city source_district source_ward source_name source_phone_number
+                     dest_city dest_district dest_ward dest_name dest_phone_number dest_address]
 
           attrs.each do |attr|
             before { order.send("#{attr}=", nil) }
@@ -58,14 +58,14 @@ RSpec.describe VNCPostAPI do
             end
           end
         end
-        context "service_id" do
+        context 'service_id' do
           before { order.service_id = 5123 }
           it do
             order.valid?
             expect(order.errors.messages.keys).to include(:service_id)
           end
         end
-        context "journey_type" do
+        context 'journey_type' do
           before { order.journey_type = 5 }
           it do
             order.valid?
@@ -75,30 +75,34 @@ RSpec.describe VNCPostAPI do
       end
     end
 
-    describe "#save" do
-      let(:token) { "abc1234567890" }
+    describe '#save' do
+      let(:token) do
+        payload = {
+          "exp": Time.now.to_i + 3600
+        }
+        JWT.encode(payload, nil)
+      end
       let(:headers) do
         {
-          "Authorization" => "Bearer #{token}",
-          "Content-Type" => "application/json"
+          'Authorization' => "Bearer #{token}",
+          'Content-Type' => 'application/json'
         }
       end
-      let(:code) { "ABC123" }
-      context "success" do
-        let(:returned_code) { "84855004010378" }
+      context 'success' do
+        let(:returned_code) { '84855004010378' }
 
         before do
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.post("/User/Login", {}, {token: token}.to_json, 200)
-            mock.post("/Order/Add",
-              headers,
-              {
-                Result: 1,
-                Message: nil,
-                Code: returned_code,
-                RouteCode: "HH949-00-00-01"
-              }.to_json,
-              200)
+            mock.post('/User/Login', {}, { token: token }.to_json, 200)
+            mock.post('/Order/Add',
+                      headers,
+                      {
+                        Result: 1,
+                        Message: nil,
+                        Code: returned_code,
+                        RouteCode: 'HH949-00-00-01'
+                      }.to_json,
+                      200)
           end
         end
         it do
@@ -111,28 +115,28 @@ RSpec.describe VNCPostAPI do
         end
       end
 
-      context "failure" do
-        context "login failed" do
+      context 'failure' do
+        context 'login failed' do
           it do
             ActiveResource::HttpMock.respond_to do |mock|
-              mock.post("/User/Login", {}, nil, 401)
+              mock.post('/User/Login', {}, nil, 401)
             end
             expect { order.save }.to raise_error(ActiveResource::UnauthorizedAccess)
           end
         end
-        context "order creation failed" do
+        context 'order creation failed' do
           before do
             ActiveResource::HttpMock.respond_to do |mock|
-              mock.post("/User/Login", {}, {token: token}.to_json, 200)
-              mock.post("/Order/Add",
-                headers,
-                {
-                  Result: 2,
-                  Message: "Đơn hàng đã tồn tại trên hệ thống!",
-                  Code: nil,
-                  RouteCode: nil
-                }.to_json,
-                200)
+              mock.post('/User/Login', {}, { token: token }.to_json, 200)
+              mock.post('/Order/Add',
+                        headers,
+                        {
+                          Result: 2,
+                          Message: 'Đơn hàng đã tồn tại trên hệ thống!',
+                          Code: nil,
+                          RouteCode: nil
+                        }.to_json,
+                        200)
             end
           end
           it { expect { order.save }.to raise_error(VNCPostAPI::ResourceInvalid) }

--- a/vncpost_api.gemspec
+++ b/vncpost_api.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Ruby object based VNCPost API wrapper."
   spec.homepage = "https://github.com/PostCo/vncpost_api"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org/"
 
@@ -26,11 +26,12 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeresource"
+  spec.add_dependency "activeresource", ">= 4.1.0"
   spec.add_dependency "jwt"
 
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "dotenv"
+  spec.add_development_dependency "zeitwerk"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
- ActiveResource 6.0.0 has a class method with name `bearer_token` which
  clashes with our method name
- Rename our own method name to `get_bearer_token`

Signed-off-by: Marcus Heng <marcushwz@gmail.com>