### PR TITLE
Update VNCPost API to V9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vncpost_api (0.3.0)
+    vncpost_api (0.3.1)
       activeresource (>= 4.1.0)
       jwt
 

--- a/lib/vncpost_api/configuration.rb
+++ b/lib/vncpost_api/configuration.rb
@@ -19,11 +19,13 @@ module VNCPostAPI
 
     def after_configure
       if config.testing?
-        VNCPostAPI::Base.site = "http://api.v3.vncpost.com"
-        VNCPostAPI::UserLogin.site = "http://api.v3.vncpost.com"
+        test_site = "http://sgp-seaedi-test.800best.com"
+        VNCPostAPI::Base.site = test_site
+        VNCPostAPI::UserLogin.site = test_site
       else
-        VNCPostAPI::Base.site = "https://u.api.vncpost.com"
-        VNCPostAPI::UserLogin.site = "https://u.api.vncpost.com"
+        production_site = "http://sgp-seaedi.800best.com"
+        VNCPostAPI::Base.site = production_site
+        VNCPostAPI::UserLogin.site = production_site
       end
       # Tracking is only available on production
       VNCPostAPI::Tracking.site = "http://pt.vncpost.com"

--- a/lib/vncpost_api/resources/order.rb
+++ b/lib/vncpost_api/resources/order.rb
@@ -44,7 +44,7 @@ module VNCPostAPI
       return_phone_number: nil
     }
 
-    self.prefix = "/Order/Add"
+    self.prefix = "/VietNamV3/v3/api/process/sears/Order/Add"
     self.element_name = ""
 
     def initialize(attributes = {}, persisted = false)

--- a/lib/vncpost_api/resources/user_login.rb
+++ b/lib/vncpost_api/resources/user_login.rb
@@ -4,7 +4,7 @@ module VNCPostAPI
   class UserLogin < ::ActiveResource::Base
     self.include_root_in_json = false
     self.include_format_in_path = false
-    self.prefix = "/User/Login"
+    self.prefix = "/VietNamV3/v3/api/process/sears/User/Login"
     self.element_name = ""
 
     class << self

--- a/spec/vncpost_api_spec.rb
+++ b/spec/vncpost_api_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe VNCPostAPI do
         return_city: 'Hà Nội',
         return_district: 'Huyện Thường Tín',
         return_ward: 'Xã Ninh Sở',
+        return_address: 'No. 12',
         return_name: 'Andy Chong',
         return_phone_number: '+84-355-5585-42'
       )
@@ -53,7 +54,7 @@ RSpec.describe VNCPostAPI do
           attrs.each do |attr|
             before { order.send("#{attr}=", nil) }
             it do
-              order.valid?
+              expect(order.valid?).to eq(false)
               expect(order.errors.messages.keys).to include(attr.to_s.to_sym)
             end
           end
@@ -93,8 +94,8 @@ RSpec.describe VNCPostAPI do
 
         before do
           ActiveResource::HttpMock.respond_to do |mock|
-            mock.post('/User/Login', {}, { token: token }.to_json, 200)
-            mock.post('/Order/Add',
+            mock.post('/VietNamV3/v3/api/process/sears/User/Login', {}, { token: token }.to_json, 200)
+            mock.post('/VietNamV3/v3/api/process/sears/Order/Add',
                       headers,
                       {
                         Result: 1,
@@ -105,12 +106,10 @@ RSpec.describe VNCPostAPI do
                       200)
           end
         end
+        
         it do
           order.save
           expect(order.code).to eq(code)
-        end
-        it do
-          order.save
           expect(order.returned_code).to eq(returned_code)
         end
       end
@@ -119,7 +118,7 @@ RSpec.describe VNCPostAPI do
         context 'login failed' do
           it do
             ActiveResource::HttpMock.respond_to do |mock|
-              mock.post('/User/Login', {}, nil, 401)
+              mock.post('/VietNamV3/v3/api/process/sears/User/Login', {}, nil, 401)
             end
             expect { order.save }.to raise_error(ActiveResource::UnauthorizedAccess)
           end
@@ -127,8 +126,8 @@ RSpec.describe VNCPostAPI do
         context 'order creation failed' do
           before do
             ActiveResource::HttpMock.respond_to do |mock|
-              mock.post('/User/Login', {}, { token: token }.to_json, 200)
-              mock.post('/Order/Add',
+              mock.post('/VietNamV3/v3/api/process/sears/User/Login', {}, { token: token }.to_json, 200)
+              mock.post('/VietNamV3/v3/api/process/sears/Order/Add',
                         headers,
                         {
                           Result: 2,


### PR DESCRIPTION
VNC/BEST Express has recently upgrade their API to V9 and older endpoint
and account is no longer working.

What this commit does:
- Update both the production and testing endpoints and prefixes

Signed-off-by: Marcus Heng <marcushwz@gmail.com>